### PR TITLE
PostgreSQL infrastructure for tasks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: focusflow-postgres
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## What
- Added PostgreSQL Docker Compose infrastructure:
  - Postgres service (postgres:16) exposed on port 5432
  - Named volume for persistent data
  - DB configuration via environment variables from `.env` (ignored by git)

## Why
- Establishes a consistent local database environment for development
- Prepares the project for migrating tasks from in-memory storage to PostgreSQL

## How to test
1. From repo root, start DB:
   ```bash
   docker compose up -d
   ```
2. Verify container is running:
   ```bash
   docker ps
   ```
## Closes
Closes #15
