### PR TITLE
Format focus durations as HH:MM:SS in stats and history

### DIFF
--- a/client/src/components/DailyFocusStats.jsx
+++ b/client/src/components/DailyFocusStats.jsx
@@ -1,12 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
+import { formatHms } from "../utils/formatTime.js";
+
 
 const API_BASE = "/api";
-
-function formatMinutes(totalSeconds) {
-  const s = Math.max(0, Number(totalSeconds || 0));
-  const minutes = Math.round(s / 60);
-  return `${minutes} min`;
-}
 
 export default function DailyFocusStats({ refreshToken }) {
   const [days, setDays] = useState(7);
@@ -82,7 +78,7 @@ export default function DailyFocusStats({ refreshToken }) {
           {items.map((d) => (
             <li key={d.date} style={{ marginBottom: 8 }}>
               <span style={{ fontWeight: 600 }}>{d.date}</span>{" "}
-              <span style={{ opacity: 0.8 }}>— {formatMinutes(d.totalSeconds)}</span>
+              <span style={{ opacity: 0.8 }}>— {formatHms(d.totalSeconds)}</span>
             </li>
           ))}
         </ul>

--- a/client/src/components/FocusHistory.jsx
+++ b/client/src/components/FocusHistory.jsx
@@ -1,14 +1,9 @@
 import { useEffect, useState } from "react";
+import { formatHms } from "../utils/formatTime.js";
+
 
 const API_BASE = "/api";
 
-function formatDuration(seconds) {
-  if (seconds === null || seconds === undefined) return "—";
-  const s = Math.max(0, Number(seconds));
-  const mm = String(Math.floor(s / 60)).padStart(2, "0");
-  const ss = String(Math.floor(s % 60)).padStart(2, "0");
-  return `${mm}:${ss}`;
-}
 
 function formatLocal(isoOrNull) {
   if (!isoOrNull) return "—";
@@ -64,7 +59,7 @@ export default function FocusHistory({ refreshToken }) {
               <li key={s.id} style={{ marginBottom: 10 }}>
                 <div style={{ fontWeight: 600 }}>{s.taskTitle ?? "Unknown task"}</div>
                 <div style={{ fontSize: 12, opacity: 0.8 }}>
-                  Duration: {formatDuration(s.durationSeconds)}{" | "}
+                  Duration: {formatHms(s.durationSeconds)}{" | "}
                   Start: {formatLocal(s.startedAt)}{" | "}
                   End: {formatLocal(s.endedAt)}
                 </div>

--- a/client/src/utils/formatTime.js
+++ b/client/src/utils/formatTime.js
@@ -1,0 +1,9 @@
+export function formatHms(totalSeconds) {
+  const s = Math.max(0, Math.floor(Number(totalSeconds || 0)));
+
+  const hh = String(Math.floor(s / 3600)).padStart(2, "0");
+  const mm = String(Math.floor((s % 3600) / 60)).padStart(2, "0");
+  const ss = String(s % 60).padStart(2, "0");
+
+  return `${hh}:${mm}:${ss}`;
+}


### PR DESCRIPTION
## What
- Standardized focus duration formatting across the UI:
  - Daily Focus Stats now display durations as HH:MM:SS
  - Focus History durations now display as HH:MM:SS
- Introduced a shared time formatting helper (`formatHms`)
- Removed unused legacy duration formatting helper

## Why
- Minute-only formatting was confusing for longer focus sessions
- HH:MM:SS improves clarity and consistency with the live focus timer
- Removing unused helpers keeps the codebase clean and easier to maintain

## How to test
1. Start server: `cd server && npm run dev`
2. Start client: `cd client && npm run dev`
3. Open the dashboard:
   - Verify Daily Focus Stats show durations in HH:MM:SS
   - Verify Focus History shows correct HH:MM:SS durations
4. Confirm no UI regressions

## Closes
Closes #31
